### PR TITLE
Fix DistinctIntervalRep::getIntervalByEndpoint bug

### DIFF
--- a/src/data_structures/distinct_interval_rep.cpp
+++ b/src/data_structures/distinct_interval_rep.cpp
@@ -54,12 +54,12 @@ namespace cg::data_structures
 
     [[nodiscard]] Interval DistinctIntervalRep::getIntervalByEndpoint(int endpoint) const
     {
-        const auto& interval = tryGetIntervalByLeftEndpoint(endpoint); 
+        const auto& interval = tryGetIntervalByLeftEndpoint(endpoint);
         if(interval)
         {
             return interval.value();
         }
-        return tryGetIntervalByLeftEndpoint(endpoint).value();
+        return tryGetIntervalByRightEndpoint(endpoint).value();
     }
 
     [[nodiscard]] Interval DistinctIntervalRep::getIntervalByIndex(int intervalIndex) const


### PR DESCRIPTION
## Summary
- search both left and right endpoint when querying an interval by endpoint

## Testing
- `./rebuild.sh` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ad55c8f488326974ef37b3817a50b