### PR TITLE
Rename interval representations

### DIFF
--- a/include/data_structures/distinct_interval_rep.h
+++ b/include/data_structures/distinct_interval_rep.h
@@ -7,7 +7,7 @@
 namespace cg::data_structures
 {
     class Interval;
-    class DistinctIntervalRep
+    class DistinctIntervalModel
     {
         std::vector<std::optional<Interval>> _leftEndpointToInterval; 
         std::vector<std::optional<Interval>> _rightEndpointToInterval; 
@@ -18,7 +18,7 @@ namespace cg::data_structures
         const int end; 
         const int size;
 
-        DistinctIntervalRep(std::span<const Interval> intervals);
+        DistinctIntervalModel(std::span<const Interval> intervals);
 
         [[nodiscard]] std::optional<Interval> tryGetIntervalByRightEndpoint(int maybeRightEndpoint) const;
         [[nodiscard]] std::optional<Interval> tryGetIntervalByLeftEndpoint(int maybeLeftEndpoint) const;

--- a/include/data_structures/shared_interval_rep.h
+++ b/include/data_structures/shared_interval_rep.h
@@ -6,14 +6,14 @@
 namespace cg::data_structures
 {
     class Interval;
-    class SharedIntervalRep
+    class SharedIntervalModel
     {
         std::vector<std::vector<Interval>> _leftEndpointToIntervals;
         std::vector<std::vector<Interval>> _rightEndpointToIntervals;
     public:
         const int end;
         const int size;
-        SharedIntervalRep(std::span<const Interval> intervals);
+        SharedIntervalModel(std::span<const Interval> intervals);
 
         [[nodiscard]] std::vector<Interval> getAllIntervalsWithLeftEndpoint(int leftEndpoint) const;
         [[nodiscard]] std::vector<Interval> getAllIntervalsWithRightEndpoint(int rightEndpoint) const;

--- a/include/mif/gavril.h
+++ b/include/mif/gavril.h
@@ -6,7 +6,7 @@
 
 namespace cg::data_structures
 {
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
     class Interval;
 }
 

--- a/include/mis/distinct/combined_output_sensitive.h
+++ b/include/mis/distinct/combined_output_sensitive.h
@@ -18,7 +18,7 @@ namespace cg::mis
 namespace cg::data_structures
 {
     class Interval;
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
 }
 
 namespace cg::mis::distinct
@@ -34,8 +34,8 @@ namespace cg::mis::distinct
             NumMembers
         };
     private:
-        static bool tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals,  int leftLimit, std::map<int, std::optional<cg::data_structures::Interval>> &pendingUpdates, cg::mis::IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals,  int leftLimit, std::map<int, std::optional<cg::data_structures::Interval>> &pendingUpdates, cg::mis::IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/distinct/implicit_output_sensitive.h
+++ b/include/mis/distinct/implicit_output_sensitive.h
@@ -16,7 +16,7 @@ namespace cg::utils
 
 namespace cg::data_structures
 {
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
     class Interval;
 }
 
@@ -41,8 +41,8 @@ namespace cg::mis::distinct
             NumMembers
         };
     private:
-        static bool tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::map<int, cg::data_structures::Interval> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &interval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::map<int, cg::data_structures::Interval> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &interval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/distinct/lazy_output_sensitive.h
+++ b/include/mis/distinct/lazy_output_sensitive.h
@@ -16,7 +16,7 @@ namespace cg::utils
 
 namespace cg::data_structures
 {
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
     class Interval;
 }
 
@@ -46,8 +46,8 @@ namespace cg::mis::distinct
             cg::data_structures::Interval interval;
             int candidate;
         };
-        static bool tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, int leftLimit, std::map<int, PendingUpdate> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, cg::mis::MonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, int leftLimit, std::map<int, PendingUpdate> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, cg::mis::MonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/distinct/naive.h
+++ b/include/mis/distinct/naive.h
@@ -11,8 +11,8 @@ namespace cg::mis::distinct
 {
     class Naive
     {
-        static void update(int endIndex, cg::mis::IndependentSet &independentSet, const cg::data_structures::DistinctIntervalRep &intervals, std::vector<int> &MIS, std::vector<int> &CMIS);
+        static void update(int endIndex, cg::mis::IndependentSet &independentSet, const cg::data_structures::DistinctIntervalModel &intervals, std::vector<int> &MIS, std::vector<int> &CMIS);
     public:
-        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalRep &intervals);
+        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalModel &intervals);
     };
 }

--- a/include/mis/distinct/pure_output_sensitive.h
+++ b/include/mis/distinct/pure_output_sensitive.h
@@ -29,8 +29,8 @@ namespace cg::mis::distinct
         };
     private:
         static void updateAt(std::stack<int> &pendingUpdates, std::vector<int> &MIS, int indexToUpdate, int newMisValue);
-        static bool tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::stack<int> &pendingUpdates, cg::mis::IndependentSet& independentSet, const cg::data_structures::Interval &interval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::stack<int> &pendingUpdates, cg::mis::IndependentSet& independentSet, const cg::data_structures::Interval &interval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/distinct/simple_implicit_output_sensitive.h
+++ b/include/mis/distinct/simple_implicit_output_sensitive.h
@@ -16,7 +16,7 @@ namespace cg::utils
 
 namespace cg::data_structures
 {
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
     class Interval;
 }
 
@@ -41,8 +41,8 @@ namespace cg::mis::distinct
             NumMembers
         };
     private:
-        static bool tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::stack<cg::data_structures::Interval> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &interval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::stack<cg::data_structures::Interval> &pendingUpdates,  cg::mis::ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &interval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/distinct/switching.h
+++ b/include/mis/distinct/switching.h
@@ -5,6 +5,6 @@ namespace cg::mis::distinct
     class Switching
     {
     public:
-        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalRep &intervals);
+        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalModel &intervals);
     };
 }

--- a/include/mis/distinct/valiente.h
+++ b/include/mis/distinct/valiente.h
@@ -7,6 +7,6 @@ namespace cg::mis::distinct
     class Valiente
     {
     public:
-        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalRep& intervals);
+        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::DistinctIntervalModel& intervals);
     };
 }

--- a/include/mis/shared/naive.h
+++ b/include/mis/shared/naive.h
@@ -12,7 +12,7 @@ namespace cg::utils
 namespace cg::data_structures
 {
     class Interval;
-    class SharedIntervalRep;
+    class SharedIntervalModel;
 }
 
 namespace cg::mis::shared
@@ -29,6 +29,6 @@ namespace cg::mis::shared
     private:
         static std::optional<cg::data_structures::Interval> getMaxInterval(std::span<const cg::data_structures::Interval> intervals, int maxRightEndpoint, std::vector<int> &MIS, std::vector<int> &CMIS, cg::utils::Counters<Counts>& counts, std::vector<cg::data_structures::Interval>& indexToLastWinner);
     public:
-        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::SharedIntervalRep &intervals, cg::utils::Counters<Counts>& counts);
+        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::SharedIntervalModel &intervals, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/shared/pruned_output_sensitive.h
+++ b/include/mis/shared/pruned_output_sensitive.h
@@ -18,7 +18,7 @@ namespace cg::mis
 namespace cg::data_structures
 {
     class Interval;
-    class SharedIntervalRep;
+    class SharedIntervalModel;
 }
 
 namespace cg::mis::shared
@@ -35,9 +35,9 @@ namespace cg::mis::shared
             NumMembers
         };
     private:
-        static bool tryUpdate(const cg::data_structures::SharedIntervalRep &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts, std::vector<std::list<cg::data_structures::Interval>>& indexToRelevantIntervals);
+        static bool tryUpdate(const cg::data_structures::SharedIntervalModel &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts, std::vector<std::list<cg::data_structures::Interval>>& indexToRelevantIntervals);
     public:
         
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::SharedIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::SharedIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/shared/pure_output_sensitive.h
+++ b/include/mis/shared/pure_output_sensitive.h
@@ -17,7 +17,7 @@ namespace cg::mis
 namespace cg::data_structures
 {
     class Interval;
-    class SharedIntervalRep;
+    class SharedIntervalModel;
 }
 
 namespace cg::mis::shared
@@ -36,9 +36,9 @@ namespace cg::mis::shared
             NumMembers
         };
     private:
-        static bool tryUpdate(const cg::data_structures::SharedIntervalRep &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static bool tryUpdate(const cg::data_structures::SharedIntervalModel &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     public:
         
-        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::SharedIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
+        static std::optional<std::vector<cg::data_structures::Interval>> tryComputeMIS(const cg::data_structures::SharedIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/mis/shared/valiente.h
+++ b/include/mis/shared/valiente.h
@@ -12,7 +12,7 @@ namespace cg::utils
 namespace cg::data_structures
 {
     class Interval;
-    class SharedIntervalRep;
+    class SharedIntervalModel;
 }
 
 namespace cg::mis::shared
@@ -29,6 +29,6 @@ namespace cg::mis::shared
     private:
         static std::optional<cg::data_structures::Interval> getMaxInterval(std::span<const cg::data_structures::Interval> intervals, int maxRightEndpoint, std::vector<int> &MIS, std::vector<int> &CMIS, cg::utils::Counters<Counts>& counts);
     public:
-        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::SharedIntervalRep &intervals, cg::utils::Counters<Counts>& counts);
+        static std::vector<cg::data_structures::Interval> computeMIS(const cg::data_structures::SharedIntervalModel &intervals, cg::utils::Counters<Counts>& counts);
     };
 }

--- a/include/utils/interval_rep_utils.h
+++ b/include/utils/interval_rep_utils.h
@@ -6,7 +6,7 @@
 namespace cg::data_structures
 {
     class Interval;
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
 }
 
 namespace cg::utils
@@ -15,7 +15,7 @@ namespace cg::utils
     void verifyEndpointsUnique(std::span<const cg::data_structures::Interval> intervals);
     void verifyIndicesDense(std::span<const cg::data_structures::Interval> intervals);
     void verifyNoOverlaps(std::span<const cg::data_structures::Interval> intervals);
-    int computeDensity(const cg::data_structures::DistinctIntervalRep& intervals);
+    int computeDensity(const cg::data_structures::DistinctIntervalModel& intervals);
     std::vector<cg::data_structures::Interval> generateRandomIntervals(int numIntervals, int seed);
     std::vector<cg::data_structures::Interval> generateRandomIntervalsShared(int numIntervals, int maxPerEndpoint, int maxLength, int seed);
     int getMaxRightEndpoint(std::span<const cg::data_structures::Interval> intervals);

--- a/include/utils/spinrad_prime.h
+++ b/include/utils/spinrad_prime.h
@@ -2,7 +2,7 @@
 
 namespace cg::data_structures
 {
-    class DistinctIntervalRep;
+    class DistinctIntervalModel;
 }
 
 namespace cg::utils
@@ -10,6 +10,6 @@ namespace cg::utils
     class SpinradPrime
     {
         public:
-            bool isPrime(const cg::data_structures::DistinctIntervalRep& intervalRep);
+            bool isPrime(const cg::data_structures::DistinctIntervalModel& intervalModel);
     };
 }

--- a/src/data_structures/distinct_interval_rep.cpp
+++ b/src/data_structures/distinct_interval_rep.cpp
@@ -7,7 +7,7 @@
 
 namespace cg::data_structures
 {
-    DistinctIntervalRep::DistinctIntervalRep(std::span<const Interval> intervals)
+    DistinctIntervalModel::DistinctIntervalModel(std::span<const Interval> intervals)
         : end(2 * intervals.size()),
           size(intervals.size())
     {
@@ -38,27 +38,27 @@ namespace cg::data_structures
 
     }
 
-    [[nodiscard]] std::optional<Interval> DistinctIntervalRep::tryGetIntervalByRightEndpoint(int maybeRightEndpoint) const
+    [[nodiscard]] std::optional<Interval> DistinctIntervalModel::tryGetIntervalByRightEndpoint(int maybeRightEndpoint) const
     {
         return _rightEndpointToInterval[maybeRightEndpoint];
     }
 
-    [[nodiscard]] std::optional<Interval> DistinctIntervalRep::tryGetIntervalByLeftEndpoint(int maybeLeftEndpoint) const
+    [[nodiscard]] std::optional<Interval> DistinctIntervalModel::tryGetIntervalByLeftEndpoint(int maybeLeftEndpoint) const
     {
         return _leftEndpointToInterval[maybeLeftEndpoint];
     }
 
-    [[nodiscard]] Interval DistinctIntervalRep::getIntervalByRightEndpoint(int rightEndpoint) const
+    [[nodiscard]] Interval DistinctIntervalModel::getIntervalByRightEndpoint(int rightEndpoint) const
     {
         return tryGetIntervalByRightEndpoint(rightEndpoint).value();
     }
 
-    [[nodiscard]] Interval DistinctIntervalRep::getIntervalByLeftEndpoint(int leftEndpoint) const
+    [[nodiscard]] Interval DistinctIntervalModel::getIntervalByLeftEndpoint(int leftEndpoint) const
     {
         return tryGetIntervalByLeftEndpoint(leftEndpoint).value();
     }
 
-    [[nodiscard]] Interval DistinctIntervalRep::getIntervalByEndpoint(int endpoint) const
+    [[nodiscard]] Interval DistinctIntervalModel::getIntervalByEndpoint(int endpoint) const
     {
         const auto& interval = tryGetIntervalByLeftEndpoint(endpoint);
         if(interval)
@@ -68,12 +68,12 @@ namespace cg::data_structures
         return tryGetIntervalByRightEndpoint(endpoint).value();
     }
 
-    [[nodiscard]] Interval DistinctIntervalRep::getIntervalByIndex(int intervalIndex) const
+    [[nodiscard]] Interval DistinctIntervalModel::getIntervalByIndex(int intervalIndex) const
     {
         return _indexToInterval[intervalIndex];
     }
 
-    [[nodiscard]] std::optional<Interval> DistinctIntervalRep::tryGetRightEndpointPredecessorInterval(int rightEndpointUpperBoundExclusive) const
+    [[nodiscard]] std::optional<Interval> DistinctIntervalModel::tryGetRightEndpointPredecessorInterval(int rightEndpointUpperBoundExclusive) const
     {
         auto it = std::lower_bound(
         _intervalsByIncreasingRightEndpoint.begin(),
@@ -92,7 +92,7 @@ namespace cg::data_structures
         return *it;
     }
 
-    [[nodiscard]] std::optional<Interval> DistinctIntervalRep::tryGetLeftEndpointPredecessorInterval(int leftEndpointUpperBoundExclusive) const
+    [[nodiscard]] std::optional<Interval> DistinctIntervalModel::tryGetLeftEndpointPredecessorInterval(int leftEndpointUpperBoundExclusive) const
     {
         auto it = std::lower_bound(
         _intervalsByIncreasingLeftEndpoint.begin(),

--- a/src/data_structures/shared_interval_rep.cpp
+++ b/src/data_structures/shared_interval_rep.cpp
@@ -8,7 +8,7 @@
 
 namespace cg::data_structures
 {
-    SharedIntervalRep::SharedIntervalRep(std::span<const Interval> intervals) : 
+    SharedIntervalModel::SharedIntervalModel(std::span<const Interval> intervals) : 
     size(intervals.size()),
     end(cg::utils::getMaxRightEndpoint(intervals) + 1)
     {
@@ -36,12 +36,12 @@ namespace cg::data_structures
     }
 
 
-    [[nodiscard]] std::vector<Interval> SharedIntervalRep::getAllIntervalsWithLeftEndpoint(int leftEndpoint) const
+    [[nodiscard]] std::vector<Interval> SharedIntervalModel::getAllIntervalsWithLeftEndpoint(int leftEndpoint) const
     {
         return _leftEndpointToIntervals[leftEndpoint];
     }
 
-    [[nodiscard]] std::vector<Interval> SharedIntervalRep::getAllIntervalsWithRightEndpoint(int rightEndpoint) const
+    [[nodiscard]] std::vector<Interval> SharedIntervalModel::getAllIntervalsWithRightEndpoint(int rightEndpoint) const
     {
         return _rightEndpointToIntervals[rightEndpoint];
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,27 +241,27 @@ int main()
             cg::utils::Counters<cg::mis::shared::Valiente::Counts> valienteCounts;
 
 
-            auto sharedIntervalRep = cg::data_structures::SharedIntervalRep(intervals);
+            auto sharedIntervalModel = cg::data_structures::SharedIntervalModel(intervals);
             auto totalLeft = 0;
             auto totalRight = 0;
-            for(auto x = 0; x < sharedIntervalRep.end; ++x)
+            for(auto x = 0; x < sharedIntervalModel.end; ++x)
             {
-                auto y = sharedIntervalRep.getAllIntervalsWithLeftEndpoint(x).size();
+                auto y = sharedIntervalModel.getAllIntervalsWithLeftEndpoint(x).size();
                 totalLeft += y;
                 //std::cout << std::format("NUM_LEFT[{}] = {}", x, y) << std::endl;
-                auto z = sharedIntervalRep.getAllIntervalsWithRightEndpoint(x).size();
+                auto z = sharedIntervalModel.getAllIntervalsWithRightEndpoint(x).size();
                 //std::cout << std::format("NUM_RIGHT[{}] = {}", x, z) << std::endl;
 
                 totalRight += z;
             }
-            auto avgLeftPerEp = totalLeft / (double) sharedIntervalRep.end;
-            auto avgRightPerEp = totalRight / (double) sharedIntervalRep.end;
+            auto avgLeftPerEp = totalLeft / (double) sharedIntervalModel.end;
+            auto avgRightPerEp = totalRight / (double) sharedIntervalModel.end;
 
 
-            std::cout << std::format("Shared interval rep of {} intervals with maxEndpointsPerPoint={}, TotalEndpoints={}, TotalIntervalLength={}, MaxIntervalLength={}, avgLeftPerEp={}, avgRightPerEp={}", intervals.size(), maxEndpointsPerPoint, sharedIntervalRep.end, totalIntervalLength, maxLength, avgLeftPerEp, avgRightPerEp) << std::endl;
+            std::cout << std::format("Shared interval rep of {} intervals with maxEndpointsPerPoint={}, TotalEndpoints={}, TotalIntervalLength={}, MaxIntervalLength={}, avgLeftPerEp={}, avgRightPerEp={}", intervals.size(), maxEndpointsPerPoint, sharedIntervalModel.end, totalIntervalLength, maxLength, avgLeftPerEp, avgRightPerEp) << std::endl;
 
 
-            auto mis1 = cg::mis::shared::Naive::computeMIS(sharedIntervalRep, naiveCounts);
+            auto mis1 = cg::mis::shared::Naive::computeMIS(sharedIntervalModel, naiveCounts);
             auto weight1 = cg::utils::sumWeights(mis1);
 
 
@@ -270,21 +270,21 @@ int main()
                                      weight1,
                                      naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerLoop),
                                      naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerMaxLoop),
-                                     naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerLoop) / (float)(sharedIntervalRep.end * sharedIntervalRep.end),
-                                     naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerMaxLoop) / (float)(sharedIntervalRep.end * numIntervals))
+                                     naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerLoop) / (float)(sharedIntervalModel.end * sharedIntervalModel.end),
+                                     naiveCounts.Get(cg::mis::shared::Naive::Counts::InnerMaxLoop) / (float)(sharedIntervalModel.end * numIntervals))
                       << std::endl;
 
-            auto mis2 = cg::mis::shared::PureOutputSensitive::tryComputeMIS(sharedIntervalRep, numIntervals, osCounts).value();
+            auto mis2 = cg::mis::shared::PureOutputSensitive::tryComputeMIS(sharedIntervalModel, numIntervals, osCounts).value();
             auto weight2 = cg::utils::sumWeights(mis2);
 
             std::cout << std::format("\tShared output sensitive IndependenceNumber={}, TotalWeight={}, OuterInterval={}, OuterStack={}, InnerStack={}, NormalizedStackTotal={}", mis2.size(), weight2,
                                      osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::IntervalOuterLoop),
                                      osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackOuterLoop),
                                      osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackInnerLoop),
-                                     (osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackOuterLoop) + osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalRep.end * mis2.size()))
+                                     (osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackOuterLoop) + osCounts.Get(cg::mis::shared::PureOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalModel.end * mis2.size()))
                       << std::endl;
 
-            auto mis3 = cg::mis::shared::Valiente::computeMIS(sharedIntervalRep, valienteCounts);
+            auto mis3 = cg::mis::shared::Valiente::computeMIS(sharedIntervalModel, valienteCounts);
             auto weight3 = cg::utils::sumWeights(mis3);
 
 
@@ -293,18 +293,18 @@ int main()
                                      weight3,
                                      valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerLoop),
                                      valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerMaxLoop),
-                                     valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerLoop) / (float)(sharedIntervalRep.end * sharedIntervalRep.end),
-                                     valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerMaxLoop) / (float)(sharedIntervalRep.end * numIntervals)) << std::endl;
+                                     valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerLoop) / (float)(sharedIntervalModel.end * sharedIntervalModel.end),
+                                     valienteCounts.Get(cg::mis::shared::Valiente::Counts::InnerMaxLoop) / (float)(sharedIntervalModel.end * numIntervals)) << std::endl;
 
-            auto mis4 = cg::mis::shared::PrunedOutputSensitive::tryComputeMIS(sharedIntervalRep, numIntervals, posCounts).value();
+            auto mis4 = cg::mis::shared::PrunedOutputSensitive::tryComputeMIS(sharedIntervalModel, numIntervals, posCounts).value();
             auto weight4 = cg::utils::sumWeights(mis4);
-            auto tmp = (long)sharedIntervalRep.end * mis4.size() / (float)numIntervals;
+            auto tmp = (long)sharedIntervalModel.end * mis4.size() / (float)numIntervals;
 
             std::cout << std::format("\tShared pruned output sensitive PRUNEFACTOR={}, IndependenceNumber={}, TotalWeight={}, OuterInterval={}, OuterStack={}, InnerStack={}, NormalizedStackTotal={}", tmp, mis4.size(), weight2,
                                      posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::IntervalOuterLoop),
                                      posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackOuterLoop),
                                      posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackInnerLoop),
-                                     (posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackOuterLoop) + posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalRep.end * mis2.size()))
+                                     (posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackOuterLoop) + posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalModel.end * mis2.size()))
                       << std::endl;
 
             if (mis1.size() != mis2.size() || mis2.size() != mis3.size() || mis3.size() != mis4.size())
@@ -365,7 +365,7 @@ int main()
         }
         
 
-        auto intervalRep = cg::data_structures::DistinctIntervalRep(intervals);
+        auto intervalModel = cg::data_structures::DistinctIntervalModel(intervals);
         long totalLength = 0;
         for (auto i : intervals)
         {
@@ -378,14 +378,14 @@ int main()
         const auto& components = cg::components::getConnectedComponents(intervals);
         std::cout << std::format("There are {} connected components of sizes: {}", components.size(), csv_sizes(components)) << std::endl;
 /*
-        auto mis = cg::mis::distinct::Naive::computeMIS(intervalRep);
+        auto mis = cg::mis::distinct::Naive::computeMIS(intervalModel);
         std::cout << std::format("Naive {}", mis.size()) << std::endl;
         for (auto i : mis)
         {
             //std::cout << std::format("{}", i) << std::endl;
         }
 */
-        auto mis2 = cg::mis::distinct::Valiente::computeMIS(intervalRep);
+        auto mis2 = cg::mis::distinct::Valiente::computeMIS(intervalModel);
         std::cout << std::format("Valiente {}", mis2.size()) << std::endl;
         for (auto i : mis2)
         {
@@ -394,7 +394,7 @@ int main()
 
         cg::utils::Counters<cg::mis::distinct::PureOutputSensitive::Counts> posCounts;
 
-        auto mis3 = cg::mis::distinct::PureOutputSensitive::tryComputeMIS(intervalRep, 1000000000, posCounts).value();
+        auto mis3 = cg::mis::distinct::PureOutputSensitive::tryComputeMIS(intervalModel, 1000000000, posCounts).value();
         std::cout << std::format("PureOutputSensitive {}", mis3.size()) << std::endl;
         for (auto i : mis3)
         {
@@ -402,17 +402,17 @@ int main()
         }
 
         //cg::utils::Counters<cg::mis::distinct::ImplicitOutputSensitive::Counts> posCounts;
-        //auto mis4 = cg::mis::distinct::ImplicitOutputSensitive::tryComputeMIS(intervalRep, intervals.size(), posCounts).value();
+        //auto mis4 = cg::mis::distinct::ImplicitOutputSensitive::tryComputeMIS(intervalModel, intervals.size(), posCounts).value();
         //std::cout << std::format("Implicit output sensitive {}", mis4.size()) << std::endl;
 
         cg::utils::Counters<cg::mis::distinct::SimpleImplicitOutputSensitive::Counts> siosCounts;
-        auto mis5 = cg::mis::distinct::SimpleImplicitOutputSensitive::tryComputeMIS(intervalRep, intervals.size(), siosCounts).value();
+        auto mis5 = cg::mis::distinct::SimpleImplicitOutputSensitive::tryComputeMIS(intervalModel, intervals.size(), siosCounts).value();
         std::cout << std::format("Simple Implicit output sensitive {}", mis5.size()) << std::endl;
 
 
         cg::utils::Counters<cg::mis::distinct::LazyOutputSensitive::Counts> losCounts;
 
-        auto mis4 = cg::mis::distinct::LazyOutputSensitive::tryComputeMIS(intervalRep, intervals.size(), losCounts).value();
+        auto mis4 = cg::mis::distinct::LazyOutputSensitive::tryComputeMIS(intervalModel, intervals.size(), losCounts).value();
 
         std::cout << std::format("Lazy output sensitive {}", mis4.size()) << std::endl;
         for (auto i : mis4)
@@ -421,7 +421,7 @@ int main()
         }
         cg::utils::Counters<cg::mis::distinct::CombinedOutputSensitive::Counts> cosCounts;
 
-        auto mis6 = cg::mis::distinct::CombinedOutputSensitive::tryComputeMIS(intervalRep, intervals.size(), cosCounts).value();
+        auto mis6 = cg::mis::distinct::CombinedOutputSensitive::tryComputeMIS(intervalModel, intervals.size(), cosCounts).value();
 
         std::cout << std::format("Combined output sensitive {}", mis6.size()) << std::endl;
 
@@ -430,7 +430,7 @@ int main()
         //                              posCounts.Get(Counts::IntervalOuterLoop),
         //                              posCounts.Get(Counts::StackOuterLoop),
         //                              posCounts.Get(Counts::StackInnerLoop),
-        //                              (posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackOuterLoop) + posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalRep.end * mis2.size()))
+        //                              (posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackOuterLoop) + posCounts.Get(cg::mis::shared::PrunedOutputSensitive::Counts::StackInnerLoop)) / (float)(sharedIntervalModel.end * mis2.size()))
         //               << std::endl;
 
 /*        if(mis3.size() != mis4.size())

--- a/src/mif/gavril.cpp
+++ b/src/mif/gavril.cpp
@@ -13,7 +13,7 @@ namespace cg::mif
 
         auto levelNumber = 0;
 
-        cg::data_structures::DistinctIntervalRep intervalRep(intervals);
+        cg::data_structures::DistinctIntervalModel intervalModel(intervals);
         while (levelEndIndex < intervals.size())
         {
             auto levelStartIndex = 3343;
@@ -24,9 +24,9 @@ namespace cg::mif
 
 
                 // may not want these loops: ? does the "The right endpoints r_w .. " begin to describe the mechanism for the computation of FR_w,i FL_w,i ?
-                for (auto x = 0; x < intervalRep.end; x++)
+                for (auto x = 0; x < intervalModel.end; x++)
                 {
-                    for (auto y = x + 1; y < intervalRep.end; ++y)
+                    for (auto y = x + 1; y < intervalModel.end; ++y)
                     {
                         // if l_w < x and r_w \in [x, y]
                         if(w_interval.Left < x && x <= w_interval.Right && w_interval.Right <= y)

--- a/src/mis/distinct/combined_output_sensitive.cpp
+++ b/src/mis/distinct/combined_output_sensitive.cpp
@@ -15,7 +15,7 @@
 namespace cg::mis::distinct
 {
 
-    bool CombinedOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, int leftLimit, std::map<int, std::optional<cg::data_structures::Interval>> &pendingUpdates, IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool CombinedOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, int leftLimit, std::map<int, std::optional<cg::data_structures::Interval>> &pendingUpdates, IndependentSet& independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> changed;
 
@@ -106,7 +106,7 @@ namespace cg::mis::distinct
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> CombinedOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> CombinedOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> MIS(intervals.end + 1, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/distinct/implicit_output_sensitive.cpp
+++ b/src/mis/distinct/implicit_output_sensitive.cpp
@@ -22,7 +22,7 @@
 
 namespace cg::mis::distinct
 {
-    bool ImplicitOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::map<int, cg::data_structures::Interval> &pendingUpdates, ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &newInterval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool ImplicitOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::map<int, cg::data_structures::Interval> &pendingUpdates, ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &newInterval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         pendingUpdates.emplace(newInterval.Left, newInterval);
         std::cout << std::format(" **** NEW INTERVAL {} DETECTED **** ", newInterval) << std::endl;
@@ -147,7 +147,7 @@ namespace cg::mis::distinct
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> ImplicitOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> ImplicitOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::map<int, cg::data_structures::Interval> pendingUpdates;
         std::vector<int> CMIS(intervals.size);

--- a/src/mis/distinct/lazy_output_sensitive.cpp
+++ b/src/mis/distinct/lazy_output_sensitive.cpp
@@ -23,7 +23,7 @@
 
 namespace cg::mis::distinct
 {
-    bool LazyOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, int leftLimit, std::map<int, PendingUpdate> &pendingUpdates, ImplicitIndependentSet& independentSet, cg::mis::MonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool LazyOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, int leftLimit, std::map<int, PendingUpdate> &pendingUpdates, ImplicitIndependentSet& independentSet, cg::mis::MonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
        
         std::vector<int> mis(intervals.end+1, 0);
@@ -151,7 +151,7 @@ namespace cg::mis::distinct
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> LazyOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> LazyOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::map<int, PendingUpdate> pendingUpdates;
         std::vector<int> CMIS(intervals.size);

--- a/src/mis/distinct/naive.cpp
+++ b/src/mis/distinct/naive.cpp
@@ -9,7 +9,7 @@
 
 namespace cg::mis::distinct
 {
-    void Naive::update(int i, cg::mis::IndependentSet &independentSet, const cg::data_structures::DistinctIntervalRep &intervals, std::vector<int> &MIS, std::vector<int> &CMIS)
+    void Naive::update(int i, cg::mis::IndependentSet &independentSet, const cg::data_structures::DistinctIntervalModel &intervals, std::vector<int> &MIS, std::vector<int> &CMIS)
     {
         for (auto j = i - 1; j >= 0; --j)
         {
@@ -32,7 +32,7 @@ namespace cg::mis::distinct
         }
     }
 
-    std::vector<cg::data_structures::Interval> Naive::computeMIS(const cg::data_structures::DistinctIntervalRep& intervals)
+    std::vector<cg::data_structures::Interval> Naive::computeMIS(const cg::data_structures::DistinctIntervalModel& intervals)
     {
         std::vector<int> MIS(intervals.end + 1, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/distinct/pure_output_sensitive.cpp
+++ b/src/mis/distinct/pure_output_sensitive.cpp
@@ -23,7 +23,7 @@ namespace cg::mis::distinct
         pendingUpdates.push(indexToUpdate);
     }
 
-    bool PureOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool PureOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::stack<int> &pendingUpdates, IndependentSet& independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::map<int, int, std::greater<int>> changed;
         changed.emplace(newInterval.Left, newInterval.Left);
@@ -88,7 +88,7 @@ namespace cg::mis::distinct
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> PureOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> PureOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> MIS(intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/distinct/simple_implicit_output_sensitive.cpp
+++ b/src/mis/distinct/simple_implicit_output_sensitive.cpp
@@ -25,7 +25,7 @@ namespace cg::mis::distinct
 {
     std::vector<int> age;
 
-    bool SimpleImplicitOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalRep &intervals, std::stack<cg::data_structures::Interval> &pendingUpdates, ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &newInterval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool SimpleImplicitOutputSensitive::tryUpdate(const cg::data_structures::DistinctIntervalModel &intervals, std::stack<cg::data_structures::Interval> &pendingUpdates, ImplicitIndependentSet& independentSet, const cg::data_structures::Interval &newInterval, cg::mis::UnitMonotoneSeq &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> mis(intervals.end+1, 0);
 
@@ -128,7 +128,7 @@ namespace cg::mis::distinct
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> SimpleImplicitOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> SimpleImplicitOutputSensitive::tryComputeMIS(const cg::data_structures::DistinctIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::stack<cg::data_structures::Interval> pendingUpdates;
         std::vector<int> CMIS(intervals.size);

--- a/src/mis/distinct/switching.cpp
+++ b/src/mis/distinct/switching.cpp
@@ -10,7 +10,7 @@
 
 namespace cg::mis::distinct
 {
-    std::vector<cg::data_structures::Interval> Switching::computeMIS(const cg::data_structures::DistinctIntervalRep &intervals)
+    std::vector<cg::data_structures::Interval> Switching::computeMIS(const cg::data_structures::DistinctIntervalModel &intervals)
     {
         int density = cg::utils::computeDensity(intervals);
         cg::utils::Counters<PureOutputSensitive::Counts> counts;

--- a/src/mis/distinct/valiente.cpp
+++ b/src/mis/distinct/valiente.cpp
@@ -9,7 +9,7 @@
 
 namespace cg::mis::distinct
 {
-    std::vector<cg::data_structures::Interval> Valiente::computeMIS(const cg::data_structures::DistinctIntervalRep& intervals)
+    std::vector<cg::data_structures::Interval> Valiente::computeMIS(const cg::data_structures::DistinctIntervalModel& intervals)
     {
         std::vector<int> MIS(intervals.end + 1, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/shared/naive.cpp
+++ b/src/mis/shared/naive.cpp
@@ -63,7 +63,7 @@ namespace cg::mis::shared
     }
 
 
-    std::vector<cg::data_structures::Interval> Naive::computeMIS(const cg::data_structures::SharedIntervalRep& intervals, cg::utils::Counters<Counts>& counts)
+    std::vector<cg::data_structures::Interval> Naive::computeMIS(const cg::data_structures::SharedIntervalModel& intervals, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> MIS(1 + intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/shared/pruned_output_sensitive.cpp
+++ b/src/mis/shared/pruned_output_sensitive.cpp
@@ -23,7 +23,7 @@ namespace cg::mis::shared
         pendingUpdates.push(indexToUpdate);
     }
 
-    bool PrunedOutputSensitive::tryUpdate(const cg::data_structures::SharedIntervalRep &intervals, std::stack<int> &pendingUpdates, IndependentSet &independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts, std::vector<std::list<cg::data_structures::Interval>>& indexToRelevantIntervals)
+    bool PrunedOutputSensitive::tryUpdate(const cg::data_structures::SharedIntervalModel &intervals, std::stack<int> &pendingUpdates, IndependentSet &independentSet, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts, std::vector<std::list<cg::data_structures::Interval>>& indexToRelevantIntervals)
     {
         while (!pendingUpdates.empty())
         {
@@ -59,7 +59,7 @@ namespace cg::mis::shared
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> PrunedOutputSensitive::tryComputeMIS(const cg::data_structures::SharedIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> PrunedOutputSensitive::tryComputeMIS(const cg::data_structures::SharedIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> MIS(intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/shared/pure_output_sensitive.cpp
+++ b/src/mis/shared/pure_output_sensitive.cpp
@@ -25,7 +25,7 @@ namespace cg::mis::shared
         pendingUpdates.push(indexToUpdate);
     }
 
-    bool PureOutputSensitive::tryUpdate(const cg::data_structures::SharedIntervalRep &intervals, std::stack<int> &pendingUpdates, IndependentSet &independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    bool PureOutputSensitive::tryUpdate(const cg::data_structures::SharedIntervalModel &intervals, std::stack<int> &pendingUpdates, IndependentSet &independentSet, const cg::data_structures::Interval &newInterval, std::vector<int> &MIS, std::vector<int> &CMIS, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         const auto candidate = newInterval.Weight + CMIS[newInterval.Index];
         if (candidate > MIS[newInterval.Left])
@@ -67,7 +67,7 @@ namespace cg::mis::shared
         return true;
     }
 
-    std::optional<std::vector<cg::data_structures::Interval>> PureOutputSensitive::tryComputeMIS(const cg::data_structures::SharedIntervalRep &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
+    std::optional<std::vector<cg::data_structures::Interval>> PureOutputSensitive::tryComputeMIS(const cg::data_structures::SharedIntervalModel &intervals, int maxAllowedMIS, cg::utils::Counters<Counts>& counts)
     {
         std::vector<int> MIS(intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/mis/shared/valiente.cpp
+++ b/src/mis/shared/valiente.cpp
@@ -34,7 +34,7 @@ namespace cg::mis::shared
         return maxInterval;
     }
 
-    std::vector<cg::data_structures::Interval> Valiente::computeMIS(const cg::data_structures::SharedIntervalRep &intervals, cg::utils::Counters<Counts> &counts)
+    std::vector<cg::data_structures::Interval> Valiente::computeMIS(const cg::data_structures::SharedIntervalModel &intervals, cg::utils::Counters<Counts> &counts)
     {
         std::vector<int> MIS(1 + intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);

--- a/src/utils/interval_rep_utils.cpp
+++ b/src/utils/interval_rep_utils.cpp
@@ -150,7 +150,7 @@
         }
     }
 
-    int computeDensity(const cg::data_structures::DistinctIntervalRep& intervals)
+    int computeDensity(const cg::data_structures::DistinctIntervalModel& intervals)
     {
         auto numOpen = 0;
         auto maxOpen = 0;

--- a/src/utils/spinrad_prime.cpp
+++ b/src/utils/spinrad_prime.cpp
@@ -4,7 +4,7 @@
 
 namespace cg::utils
 {
-    bool SpinradPrime::isPrime(const cg::data_structures::DistinctIntervalRep& intervalRep)
+    bool SpinradPrime::isPrime(const cg::data_structures::DistinctIntervalModel& intervalModel)
     {
 
         return true;


### PR DESCRIPTION
## Summary
- rename DistinctIntervalRep to DistinctIntervalModel
- rename SharedIntervalRep to SharedIntervalModel
- update variable names using these types

## Testing
- `./rebuild.sh`
- `./circle-graphs-tests`

------
https://chatgpt.com/codex/tasks/task_e_684bc9cd677c8326a95cd47528a0fce5