### PR TITLE
Report MIS results without early exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include <array>
 #include <limits>
 #include <string_view>
+#include <vector>
+#include <utility>
 
 #include "data_structures/interval.h"
 #include "data_structures/distinct_interval_model.h"
@@ -30,42 +32,46 @@ int main()
     data_structures::DistinctIntervalModel distinctModel(intervals);
     data_structures::SharedIntervalModel sharedModel(intervals);
 
+    std::vector<std::pair<std::string_view, std::size_t>> results;
+
     // Distinct endpoint algorithms
     auto misDistinctNaive = mis::distinct::Naive::computeMIS(distinctModel);
     std::size_t expectedSize = misDistinctNaive.size();
+    results.emplace_back("distinct naive", misDistinctNaive.size());
+
     auto misDistinctValiente = mis::distinct::Valiente::computeMIS(distinctModel);
-    if (misDistinctValiente.size() != expectedSize) return 1;
+    results.emplace_back("distinct valiente", misDistinctValiente.size());
 
     const std::array<std::string_view,3> dsLabels{"StackOuter","StackInner","IntervalOuter"};
 
     {
         utils::Counters<mis::distinct::PureOutputSensitive::Counts> counts;
         auto mis = mis::distinct::PureOutputSensitive::tryComputeMIS(distinctModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("distinct pure_output_sensitive", mis.size());
         utils::report("distinct pure_output_sensitive", counts, dsLabels);
     }
     {
         utils::Counters<mis::distinct::CombinedOutputSensitive::Counts> counts;
         auto mis = mis::distinct::CombinedOutputSensitive::tryComputeMIS(distinctModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("distinct combined_output_sensitive", mis.size());
         utils::report("distinct combined_output_sensitive", counts, dsLabels);
     }
     {
         utils::Counters<mis::distinct::SimpleImplicitOutputSensitive::Counts> counts;
         auto mis = mis::distinct::SimpleImplicitOutputSensitive::tryComputeMIS(distinctModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("distinct simple_implicit_output_sensitive", mis.size());
         utils::report("distinct simple_implicit_output_sensitive", counts, dsLabels);
     }
     {
         utils::Counters<mis::distinct::ImplicitOutputSensitive::Counts> counts;
         auto mis = mis::distinct::ImplicitOutputSensitive::tryComputeMIS(distinctModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("distinct implicit_output_sensitive", mis.size());
         utils::report("distinct implicit_output_sensitive", counts, dsLabels);
     }
     {
         utils::Counters<mis::distinct::LazyOutputSensitive::Counts> counts;
         auto mis = mis::distinct::LazyOutputSensitive::tryComputeMIS(distinctModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("distinct lazy_output_sensitive", mis.size());
         utils::report("distinct lazy_output_sensitive", counts, dsLabels);
     }
 
@@ -75,27 +81,50 @@ int main()
 
     utils::Counters<mis::shared::Naive::Counts> sharedNaiveCounts;
     auto misSharedNaive = mis::shared::Naive::computeMIS(sharedModel, sharedNaiveCounts);
-    if (misSharedNaive.size() != expectedSize) return 1;
+    results.emplace_back("shared naive", misSharedNaive.size());
     utils::report("shared naive", sharedNaiveCounts, sdLabels);
 
     utils::Counters<mis::shared::Valiente::Counts> sharedValienteCounts;
     auto misSharedValiente = mis::shared::Valiente::computeMIS(sharedModel, sharedValienteCounts);
-    if (misSharedValiente.size() != expectedSize) return 1;
+    results.emplace_back("shared valiente", misSharedValiente.size());
     utils::report("shared valiente", sharedValienteCounts, sdLabels);
 
     {
         utils::Counters<mis::shared::PureOutputSensitive::Counts> counts;
         auto mis = mis::shared::PureOutputSensitive::tryComputeMIS(sharedModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("shared pure_output_sensitive", mis.size());
         utils::report("shared pure_output_sensitive", counts, ssLabels);
     }
     {
         utils::Counters<mis::shared::PrunedOutputSensitive::Counts> counts;
         auto mis = mis::shared::PrunedOutputSensitive::tryComputeMIS(sharedModel, std::numeric_limits<int>::max(), counts).value();
-        if (mis.size() != expectedSize) return 1;
+        results.emplace_back("shared pruned_output_sensitive", mis.size());
         utils::report("shared pruned_output_sensitive", counts, ssLabels);
     }
 
-    std::cout << "All algorithms agree on MIS size " << expectedSize << "\n";
-    return 0;
+    bool allMatch = true;
+    for (const auto& [name, size] : results)
+    {
+        std::cout << name << " MIS size: " << size << "\n";
+        if (size != expectedSize)
+        {
+            allMatch = false;
+        }
+    }
+
+    if (allMatch)
+    {
+        std::cout << "All algorithms agree on MIS size " << expectedSize << "\n";
+        return 0;
+    }
+
+    std::cout << "Algorithms disagree on MIS size. Expected " << expectedSize << "\n";
+    for (const auto& [name, size] : results)
+    {
+        if (size != expectedSize)
+        {
+            std::cout << " - " << name << " size: " << size << "\n";
+        }
+    }
+    return 1;
 }

--- a/src/mis/shared/naive.cpp
+++ b/src/mis/shared/naive.cpp
@@ -61,7 +61,8 @@ namespace cg::mis::shared
     {
         std::vector<int> MIS(1 + intervals.end, 0);
         std::vector<int> CMIS(intervals.size, 0);
-        std::vector<cg::data_structures::Interval> indexToLastWinner(intervals.size, cg::data_structures::Interval(0, 1, 0, -1));
+        std::vector<cg::data_structures::Interval> indexToLastWinner(intervals.end + 1,
+                                                                      cg::data_structures::Interval(0, 1, 0, -1));
         cg::mis::IndependentSet independentSet(intervals.size);
 
         for(auto right = 1; right < intervals.end + 1; ++right)


### PR DESCRIPTION
## Summary
- Collect MIS sizes for every distinct and shared algorithm and report mismatches instead of returning early.
- Resize shared MIS naive helper to use endpoint-based array, avoiding out-of-bounds access.
- Place braces on new lines in final MIS comparison reporting.

## Testing
- `./rebuild.sh`
- `cd build && ctest`
- `./circle-graphs`


------
https://chatgpt.com/codex/tasks/task_e_68b96b607a7c8326924d04a3f75afb00