### PR TITLE
Implement O(n^5) maximum induced forest solver

### DIFF
--- a/include/mif/maximum_induced_forest_on5.h
+++ b/include/mif/maximum_induced_forest_on5.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "data_structures/interval.h"
+#include "data_structures/distinct_interval_model.h"
+
+namespace cg::mif
+{
+    class MaximumInducedForestOn5
+    {
+    public:
+        [[nodiscard]] static int computeMifSize(const cg::data_structures::DistinctIntervalModel &intervalModel);
+    };
+}
+

--- a/src/mif/maximum_induced_forest_on5.cpp
+++ b/src/mif/maximum_induced_forest_on5.cpp
@@ -1,0 +1,604 @@
+#include "mif/maximum_induced_forest_on5.h"
+
+#include "data_structures/interval.h"
+#include "utils/array_utils.h"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+namespace
+{
+    using Interval = cg::data_structures::Interval;
+
+    class MaximumInducedForestOn5Impl
+    {
+    public:
+        explicit MaximumInducedForestOn5Impl(const cg::data_structures::DistinctIntervalModel &model)
+            : _n(model.size),
+              _maxEndpoint(0),
+              _leftChildren(_n),
+              _rightChildren(_n),
+              _leftBuilt(static_cast<std::size_t>(_n), false),
+              _rightBuilt(static_cast<std::size_t>(_n), false)
+        {
+            if (_n == 0)
+            {
+                return;
+            }
+
+            auto original = model.getAllIntervals();
+            _intervals.reserve(original.size());
+            for (const auto &interval : original)
+            {
+                _intervals.emplace_back(interval.Left + 1, interval.Right + 1, interval.Index, interval.Weight);
+            }
+
+            _maxEndpoint = computeMaxEndpoint();
+            const int stride = _maxEndpoint + 1;
+
+            _leftForests = cg::utils::array3<int>(_n, stride, stride, 0);
+            _rightForests = cg::utils::array3<int>(_n, stride, stride, 0);
+            _rootCache = cg::utils::array3<int>(_n, stride, stride, -1);
+            _leftDummy = cg::utils::array2<int>(_n, stride, -1);
+            _rightDummy = cg::utils::array3<int>(_n, stride, stride, -1);
+
+            _ldInProgress.assign(static_cast<std::size_t>(_n), std::vector<bool>(stride, false));
+            _rdInProgress.assign(static_cast<std::size_t>(_n) * stride * stride, false);
+
+            _endpoints.reserve(1 + 2 * static_cast<std::size_t>(_n));
+            _endpoints.push_back(0);
+            for (const auto &interval : _intervals)
+            {
+                _endpoints.push_back(interval.Left);
+                _endpoints.push_back(interval.Right);
+            }
+            std::sort(_endpoints.begin(), _endpoints.end());
+            _endpoints.erase(std::unique(_endpoints.begin(), _endpoints.end()), _endpoints.end());
+
+            buildChildren();
+        }
+
+        [[nodiscard]] int solve()
+        {
+            if (_n == 0)
+            {
+                return 0;
+            }
+
+            const int Emax = _maxEndpoint;
+            int best = 0;
+            for (int w = 0; w < _n; ++w)
+            {
+                const auto &root = _intervals[w];
+                for (int split = root.Left; split < root.Right; ++split)
+                {
+                    const int leftScore = LF_side(w, 0, split);
+                    const int rightScore = RF_side(w, split + 1, Emax);
+                    best = std::max(best, 1 + leftScore + rightScore);
+                }
+            }
+            return best;
+        }
+
+    private:
+        std::vector<Interval> _intervals;
+        int _n;
+        int _maxEndpoint;
+        std::vector<int> _endpoints;
+        std::vector<std::vector<int>> _leftChildren;
+        std::vector<std::vector<int>> _rightChildren;
+        cg::utils::array3<int> _leftForests;
+        cg::utils::array3<int> _rightForests;
+        cg::utils::array3<int> _rootCache;
+        cg::utils::array2<int> _leftDummy;
+        cg::utils::array3<int> _rightDummy;
+        std::vector<bool> _leftBuilt;
+        std::vector<bool> _rightBuilt;
+        std::vector<std::vector<bool>> _ldInProgress;
+        std::vector<bool> _rdInProgress;
+
+        [[nodiscard]] int computeMaxEndpoint() const
+        {
+            int result = 0;
+            for (const auto &interval : _intervals)
+            {
+                result = std::max(result, interval.Left);
+                result = std::max(result, interval.Right);
+            }
+            return result;
+        }
+
+        void buildChildren()
+        {
+            for (int w = 0; w < _n; ++w)
+            {
+                const auto &outer = _intervals[w];
+                for (int v = 0; v < _n; ++v)
+                {
+                    if (v == w)
+                    {
+                        continue;
+                    }
+                    const auto &inner = _intervals[v];
+                    if (inner.Left < outer.Left && outer.Left < inner.Right && inner.Right < outer.Right)
+                    {
+                        _leftChildren[w].push_back(v);
+                    }
+                    if (outer.Left < inner.Left && inner.Left < outer.Right && outer.Right < inner.Right)
+                    {
+                        _rightChildren[w].push_back(v);
+                    }
+                }
+                const auto compareByLeft = [this](int lhs, int rhs)
+                {
+                    return _intervals[lhs].Left < _intervals[rhs].Left;
+                };
+                std::sort(_leftChildren[w].begin(), _leftChildren[w].end(), compareByLeft);
+                std::sort(_rightChildren[w].begin(), _rightChildren[w].end(), compareByLeft);
+            }
+        }
+
+        [[nodiscard]] int LF_side(int w, int a, int b)
+        {
+            if (w < 0 || w >= _n || a < 0 || b < 0 || a > _maxEndpoint || b > _maxEndpoint)
+            {
+                return 0;
+            }
+            const auto &interval = _intervals[w];
+            if (a == interval.Left)
+            {
+                if (b > interval.Left && b < interval.Right)
+                {
+                    return LD(w, b);
+                }
+                return 0;
+            }
+            if (!_leftBuilt[static_cast<std::size_t>(w)])
+            {
+                buildLeft(w);
+            }
+            return _leftForests(w, a, b);
+        }
+
+        [[nodiscard]] int RF_side(int w, int a, int b)
+        {
+            if (w < 0 || w >= _n || a < 0 || b < 0 || a > _maxEndpoint || b > _maxEndpoint)
+            {
+                return 0;
+            }
+            if (!_rightBuilt[static_cast<std::size_t>(w)])
+            {
+                buildRight(w);
+            }
+            return _rightForests(w, a, b);
+        }
+
+        [[nodiscard]] int ROOT(int v, int L, int R)
+        {
+            if (v < 0 || v >= _n || L < 0 || R < 0 || L > _maxEndpoint || R > _maxEndpoint)
+            {
+                return 0;
+            }
+            int &memo = _rootCache(v, L, R);
+            if (memo != -1)
+            {
+                return memo;
+            }
+
+            const auto &interval = _intervals[v];
+            if (!(L == interval.Left && interval.Right <= R))
+            {
+                memo = 0;
+                return memo;
+            }
+
+            int best = 0;
+            for (int split = interval.Left; split < interval.Right; ++split)
+            {
+                const int leftScore = LF_side(v, L, split);
+                const int rightScore = RF_side(v, split + 1, R);
+                best = std::max(best, 1 + leftScore + rightScore);
+            }
+            memo = best;
+            return memo;
+        }
+
+        [[nodiscard]] int LD(int w, int q)
+        {
+            const auto &interval = _intervals[w];
+            if (q <= interval.Left || q > _maxEndpoint)
+            {
+                return 0;
+            }
+            int &memo = _leftDummy(w, q);
+            if (memo != -1)
+            {
+                return memo;
+            }
+            if (_ldInProgress[static_cast<std::size_t>(w)][q])
+            {
+                return 0;
+            }
+            _ldInProgress[static_cast<std::size_t>(w)][q] = true;
+
+            int best = 0;
+            for (int v = 0; v < _n; ++v)
+            {
+                if (v == w)
+                {
+                    continue;
+                }
+                const auto &candidate = _intervals[v];
+                if (candidate.Left > interval.Left && candidate.Right <= q)
+                {
+                    best = std::max(best, ROOT(v, candidate.Left, q));
+                }
+            }
+
+            memo = best;
+            _ldInProgress[static_cast<std::size_t>(w)][q] = false;
+            return memo;
+        }
+
+        [[nodiscard]] bool rdInProgress(int w, int a, int y) const
+        {
+            const int stride = _maxEndpoint + 1;
+            std::size_t index = (static_cast<std::size_t>(w) * stride + static_cast<std::size_t>(a)) * stride + static_cast<std::size_t>(y);
+            return _rdInProgress[index];
+        }
+
+        void setRdInProgress(int w, int a, int y, bool value)
+        {
+            const int stride = _maxEndpoint + 1;
+            std::size_t index = (static_cast<std::size_t>(w) * stride + static_cast<std::size_t>(a)) * stride + static_cast<std::size_t>(y);
+            _rdInProgress[index] = value;
+        }
+
+        [[nodiscard]] int RD(int w, int a, int y)
+        {
+            const auto &interval = _intervals[w];
+            if (a < 0 || y < 0 || a > _maxEndpoint || y > _maxEndpoint)
+            {
+                return 0;
+            }
+            if (a > y || y <= interval.Right)
+            {
+                return 0;
+            }
+
+            int &memo = _rightDummy(w, a, y);
+            if (memo != -1)
+            {
+                return memo;
+            }
+            if (rdInProgress(w, a, y))
+            {
+                return 0;
+            }
+            setRdInProgress(w, a, y, true);
+
+            int best = 0;
+            const int threshold = std::max(a, interval.Right + 1);
+            for (int v = 0; v < _n; ++v)
+            {
+                if (v == w)
+                {
+                    continue;
+                }
+                const auto &candidate = _intervals[v];
+                if (candidate.Left >= threshold && candidate.Right <= y)
+                {
+                    best = std::max(best, ROOT(v, candidate.Left, y));
+                }
+            }
+
+            memo = best;
+            setRdInProgress(w, a, y, false);
+            return memo;
+        }
+
+        void buildLeft(int w)
+        {
+            if (_leftBuilt[static_cast<std::size_t>(w)])
+            {
+                return;
+            }
+            _leftBuilt[static_cast<std::size_t>(w)] = true;
+
+            const auto &root = _intervals[w];
+            const int lw = root.Left;
+            const int rw = root.Right;
+
+            std::vector<int> Z;
+            std::vector<int> Y;
+            for (int endpoint : _endpoints)
+            {
+                if (endpoint < lw)
+                {
+                    Z.push_back(endpoint);
+                }
+                else if (endpoint > lw && endpoint < rw)
+                {
+                    Y.push_back(endpoint);
+                }
+            }
+
+            if (Z.empty() || Y.empty())
+            {
+                return;
+            }
+
+            const auto &children = _leftChildren[w];
+            const int Az = static_cast<int>(Z.size());
+            const int By = static_cast<int>(Y.size());
+            const int NEG_INF = std::numeric_limits<int>::min() / 4;
+
+            std::vector<int> D(By, 0);
+            for (int j = 0; j < By; ++j)
+            {
+                D[j] = LD(w, Y[j]);
+            }
+
+            std::vector<std::vector<int>> S_next(Az, std::vector<int>(By, 0));
+            for (int i = 0; i < Az; ++i)
+            {
+                for (int j = 0; j < By; ++j)
+                {
+                    S_next[i][j] = D[j];
+                }
+            }
+
+            for (int childPos = static_cast<int>(children.size()) - 1; childPos >= 0; --childPos)
+            {
+                const int u = children[childPos];
+                const auto &child = _intervals[u];
+                const int lu = child.Left;
+                const int ru = child.Right;
+
+                std::vector<std::vector<int>> M(Az, std::vector<int>(By, NEG_INF));
+                for (int j = 0; j < By; ++j)
+                {
+                    const int b = Y[j];
+                    const int limit = std::min(b, ru);
+                    const auto upperIt = std::upper_bound(Y.begin(), Y.end(), limit);
+                    const int j_ymax = static_cast<int>(upperIt - Y.begin()) - 1;
+                    if (j_ymax < 0)
+                    {
+                        continue;
+                    }
+
+                    std::vector<int> RF_row(j_ymax + 1, 0);
+                    for (int jj = 0; jj <= j_ymax; ++jj)
+                    {
+                        RF_row[jj] = RF_side(u, Y[jj], b);
+                    }
+
+                    for (int ii = 0; ii < Az; ++ii)
+                    {
+                        int best = NEG_INF;
+                        for (int jj = 0; jj <= j_ymax; ++jj)
+                        {
+                            const int cand = S_next[ii][jj] + RF_row[jj];
+                            if (cand > best)
+                            {
+                                best = cand;
+                            }
+                        }
+                        M[ii][j] = best;
+                    }
+                }
+
+                auto S_cur = S_next;
+                for (int i = 0; i < Az; ++i)
+                {
+                    const int a = Z[i];
+                    for (int j = 0; j < By; ++j)
+                    {
+                        if (D[j] > S_cur[i][j])
+                        {
+                            S_cur[i][j] = D[j];
+                        }
+
+                        const int z_lb = std::max(a, lu);
+                        const auto startIt = std::lower_bound(Z.begin(), Z.end(), z_lb);
+                        int ii_start = static_cast<int>(startIt - Z.begin());
+                        if (ii_start >= Az)
+                        {
+                            continue;
+                        }
+
+                        int best = NEG_INF;
+                        for (int ii = ii_start; ii < Az; ++ii)
+                        {
+                            const int leftValue = LF_side(u, a, Z[ii]);
+                            const int bridge = M[ii][j];
+                            if (bridge <= NEG_INF / 2)
+                            {
+                                continue;
+                            }
+                            const int cand = leftValue + bridge;
+                            if (cand > best)
+                            {
+                                best = cand;
+                            }
+                        }
+                        if (best <= NEG_INF / 2)
+                        {
+                            continue;
+                        }
+
+                        const int cand = 1 + best;
+                        if (cand > S_cur[i][j])
+                        {
+                            S_cur[i][j] = cand;
+                        }
+                    }
+                }
+
+                S_next.swap(S_cur);
+            }
+
+            for (int i = 0; i < Az; ++i)
+            {
+                const int a = Z[i];
+                for (int j = 0; j < By; ++j)
+                {
+                    _leftForests(w, a, Y[j]) = S_next[i][j];
+                }
+            }
+        }
+
+        void buildRight(int w)
+        {
+            if (_rightBuilt[static_cast<std::size_t>(w)])
+            {
+                return;
+            }
+            _rightBuilt[static_cast<std::size_t>(w)] = true;
+
+            const auto &root = _intervals[w];
+            const int lw = root.Left;
+            const int rw = root.Right;
+
+            std::vector<int> Z;
+            std::vector<int> Y;
+            for (int endpoint : _endpoints)
+            {
+                if (endpoint >= lw && endpoint <= rw)
+                {
+                    Z.push_back(endpoint);
+                }
+                else if (endpoint > rw)
+                {
+                    Y.push_back(endpoint);
+                }
+            }
+
+            if (Z.empty() || Y.empty())
+            {
+                return;
+            }
+
+            const auto &children = _rightChildren[w];
+            const int Az = static_cast<int>(Z.size());
+            const int By = static_cast<int>(Y.size());
+            const int NEG_INF = std::numeric_limits<int>::min() / 4;
+
+            std::vector<std::vector<int>> S_next(Az, std::vector<int>(By, 0));
+            for (int i = 0; i < Az; ++i)
+            {
+                for (int j = 0; j < By; ++j)
+                {
+                    S_next[i][j] = RD(w, Z[i], Y[j]);
+                }
+            }
+
+            const auto lowerRwPlusOne = std::lower_bound(Y.begin(), Y.end(), rw + 1);
+            const int j_lo_base = static_cast<int>(lowerRwPlusOne - Y.begin());
+
+            for (int childPos = static_cast<int>(children.size()) - 1; childPos >= 0; --childPos)
+            {
+                const int v = children[childPos];
+                const auto &child = _intervals[v];
+                const int lv = child.Left;
+                const int rv = child.Right;
+
+                std::vector<std::vector<int>> M(Az, std::vector<int>(By, NEG_INF));
+                for (int j = 0; j < By; ++j)
+                {
+                    const int b = Y[j];
+                    const int upperBound = std::min(b, rv);
+                    const auto hiIt = std::upper_bound(Y.begin(), Y.end(), upperBound);
+                    int j_hi = static_cast<int>(hiIt - Y.begin()) - 1;
+                    int j_lo = j_lo_base;
+                    if (j_lo > j_hi)
+                    {
+                        continue;
+                    }
+
+                    std::vector<int> RF_row;
+                    RF_row.reserve(static_cast<std::size_t>(j_hi - j_lo + 1));
+                    for (int jx = j_lo; jx <= j_hi; ++jx)
+                    {
+                        RF_row.push_back(RF_side(v, Y[jx], b));
+                    }
+
+                    for (int ii = 0; ii < Az; ++ii)
+                    {
+                        int best = NEG_INF;
+                        for (int offset = 0, jx = j_lo; jx <= j_hi; ++jx, ++offset)
+                        {
+                            const int cand = S_next[ii][jx] + RF_row[static_cast<std::size_t>(offset)];
+                            if (cand > best)
+                            {
+                                best = cand;
+                            }
+                        }
+                        M[ii][j] = best;
+                    }
+                }
+
+                auto S_cur = S_next;
+                for (int i = 0; i < Az; ++i)
+                {
+                    const int a = Z[i];
+                    const auto startIt = std::lower_bound(Z.begin(), Z.end(), std::max(a, lv));
+                    const auto endIt = std::upper_bound(Z.begin(), Z.end(), rw - 1);
+                    const int ii_start = static_cast<int>(startIt - Z.begin());
+                    const int ii_end = static_cast<int>(endIt - Z.begin()) - 1;
+                    if (ii_start > ii_end)
+                    {
+                        continue;
+                    }
+
+                    for (int j = 0; j < By; ++j)
+                    {
+                        int best = NEG_INF;
+                        for (int ii = ii_start; ii <= ii_end; ++ii)
+                        {
+                            const int bridge = M[ii][j];
+                            if (bridge <= NEG_INF / 2)
+                            {
+                                continue;
+                            }
+                            const int cand = LF_side(v, a, Z[ii]) + bridge;
+                            if (cand > best)
+                            {
+                                best = cand;
+                            }
+                        }
+                        if (best <= NEG_INF / 2)
+                        {
+                            continue;
+                        }
+
+                        const int cand = 1 + best;
+                        if (cand > S_cur[i][j])
+                        {
+                            S_cur[i][j] = cand;
+                        }
+                    }
+                }
+
+                S_next.swap(S_cur);
+            }
+
+            for (int i = 0; i < Az; ++i)
+            {
+                const int a = Z[i];
+                for (int j = 0; j < By; ++j)
+                {
+                    _rightForests(w, a, Y[j]) = S_next[i][j];
+                }
+            }
+        }
+    };
+}
+
+int cg::mif::MaximumInducedForestOn5::computeMifSize(const cg::data_structures::DistinctIntervalModel &intervalModel)
+{
+    MaximumInducedForestOn5Impl solver(intervalModel);
+    return solver.solve();
+}
+

--- a/tests/mif/maximum_induced_forest_on5_tests.cpp
+++ b/tests/mif/maximum_induced_forest_on5_tests.cpp
@@ -1,0 +1,377 @@
+#include "doctest/doctest.h"
+
+#include "data_structures/interval.h"
+#include "data_structures/distinct_interval_model.h"
+#include "mif/maximum_induced_forest_on5.h"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+namespace cgtd = cg::data_structures;
+
+namespace
+{
+    [[nodiscard]] cgtd::Interval mk(int L, int R, int idx, int w = 1)
+    {
+        if (L > R)
+        {
+            std::swap(L, R);
+        }
+        return cgtd::Interval(L, R, idx, w);
+    }
+
+    void validateEndpoints(const std::vector<cgtd::Interval> &intervals)
+    {
+        const int n = static_cast<int>(intervals.size());
+        REQUIRE(n > 0);
+        std::vector<int> endpoints;
+        endpoints.reserve(2 * n);
+        for (const auto &interval : intervals)
+        {
+            endpoints.push_back(interval.Left);
+            endpoints.push_back(interval.Right);
+        }
+        std::sort(endpoints.begin(), endpoints.end());
+        for (int i = 0; i < 2 * n; ++i)
+        {
+            REQUIRE(endpoints[i] == i);
+        }
+    }
+
+    bool overlapsStrict(const cgtd::Interval &a, const cgtd::Interval &b)
+    {
+        return (a.Left < b.Left && b.Left < a.Right && a.Right < b.Right) ||
+               (b.Left < a.Left && a.Left < b.Right && b.Right < a.Right);
+    }
+
+    std::vector<std::vector<int>> buildAdjacency(const std::vector<cgtd::Interval> &intervals)
+    {
+        const int n = static_cast<int>(intervals.size());
+        std::vector<std::vector<int>> graph(n);
+        for (int i = 0; i < n; ++i)
+        {
+            for (int j = i + 1; j < n; ++j)
+            {
+                if (overlapsStrict(intervals[i], intervals[j]))
+                {
+                    graph[i].push_back(j);
+                    graph[j].push_back(i);
+                }
+            }
+        }
+        return graph;
+    }
+
+    bool isForestInduced(const std::vector<cgtd::Interval> &intervals, const std::vector<int> &picked)
+    {
+        const auto graph = buildAdjacency(intervals);
+        std::unordered_map<int, int> indexOf;
+        indexOf.reserve(picked.size());
+        for (int pos = 0; pos < static_cast<int>(picked.size()); ++pos)
+        {
+            indexOf.emplace(picked[pos], pos);
+        }
+        const int k = static_cast<int>(picked.size());
+        std::vector<std::vector<int>> subgraph(k);
+        for (int pos = 0; pos < k; ++pos)
+        {
+            const int original = picked[pos];
+            for (int neighbor : graph[original])
+            {
+                auto it = indexOf.find(neighbor);
+                if (it != indexOf.end())
+                {
+                    subgraph[pos].push_back(it->second);
+                }
+            }
+        }
+        std::vector<int> color(k, 0);
+        std::function<bool(int, int)> dfs = [&](int node, int parent)
+        {
+            color[node] = 1;
+            for (int neighbor : subgraph[node])
+            {
+                if (neighbor == parent)
+                {
+                    continue;
+                }
+                if (color[neighbor] == 1)
+                {
+                    return false;
+                }
+                if (color[neighbor] == 0 && !dfs(neighbor, node))
+                {
+                    return false;
+                }
+            }
+            color[node] = 2;
+            return true;
+        };
+        for (int i = 0; i < k; ++i)
+        {
+            if (color[i] == 0 && !dfs(i, -1))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    int bruteForceMifSize(const std::vector<cgtd::Interval> &intervals)
+    {
+        const int n = static_cast<int>(intervals.size());
+        REQUIRE(n <= 20);
+        int best = 0;
+        std::vector<int> picked;
+        picked.reserve(n);
+        for (unsigned mask = 1; mask < (1u << n); ++mask)
+        {
+            picked.clear();
+            for (int i = 0; i < n; ++i)
+            {
+                if (mask & (1u << i))
+                {
+                    picked.push_back(i);
+                }
+            }
+            if (static_cast<int>(picked.size()) <= best)
+            {
+                continue;
+            }
+            if (isForestInduced(intervals, picked))
+            {
+                best = static_cast<int>(picked.size());
+            }
+        }
+        return best;
+    }
+
+    std::vector<cgtd::Interval> makeIntervalsFromPermutation(const std::vector<int> &perm)
+    {
+        const int n = static_cast<int>(perm.size()) / 2;
+        std::vector<cgtd::Interval> intervals;
+        intervals.reserve(n);
+        for (int i = 0; i < n; ++i)
+        {
+            const int a = perm[2 * i];
+            const int b = perm[2 * i + 1];
+            intervals.push_back(mk(a, b, i));
+        }
+        validateEndpoints(intervals);
+        return intervals;
+    }
+
+    int maximumInducedForestOn5Size(const std::vector<cgtd::Interval> &intervals)
+    {
+        cgtd::DistinctIntervalModel model(intervals);
+        return cg::mif::MaximumInducedForestOn5::computeMifSize(model);
+    }
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Single edge is fully kept")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 2, 0));
+    intervals.push_back(mk(1, 3, 1));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 2);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Single dummy left child")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 3, 0));
+    intervals.push_back(mk(1, 2, 1));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Three nested intervals")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 5, 0));
+    intervals.push_back(mk(1, 4, 1));
+    intervals.push_back(mk(2, 3, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 3);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Four nested intervals")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 7, 0));
+    intervals.push_back(mk(1, 6, 1));
+    intervals.push_back(mk(2, 5, 2));
+    intervals.push_back(mk(3, 4, 3));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 4);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Two disjoint intervals")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 1, 0));
+    intervals.push_back(mk(2, 3, 1));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 2);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Three disjoint intervals")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 1, 0));
+    intervals.push_back(mk(2, 3, 1));
+    intervals.push_back(mk(4, 5, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 3);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Single interval containing two disjoint")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 5, 0));
+    intervals.push_back(mk(1, 2, 1));
+    intervals.push_back(mk(3, 4, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 3);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Single interval containing three disjoint")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 7, 0));
+    intervals.push_back(mk(1, 2, 1));
+    intervals.push_back(mk(3, 4, 2));
+    intervals.push_back(mk(5, 6, 3));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 4);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Triangle reduces to 2")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 3, 0));
+    intervals.push_back(mk(1, 4, 1));
+    intervals.push_back(mk(2, 5, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 2);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Disconnected forest stays whole")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 2, 0));
+    intervals.push_back(mk(1, 3, 1));
+    intervals.push_back(mk(4, 6, 2));
+    intervals.push_back(mk(5, 7, 3));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 4);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Triangle plus edge")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 3, 0));
+    intervals.push_back(mk(1, 4, 1));
+    intervals.push_back(mk(2, 5, 2));
+    intervals.push_back(mk(6, 8, 3));
+    intervals.push_back(mk(7, 9, 4));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(expected == 4);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Mixed nested + overlaps")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(1, 6, 0));
+    intervals.push_back(mk(2, 5, 1));
+    intervals.push_back(mk(0, 4, 2));
+    intervals.push_back(mk(3, 7, 3));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Left and right dummies right dummy first")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 1, 0));
+    intervals.push_back(mk(2, 5, 1));
+    intervals.push_back(mk(3, 4, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Left and right dummies left dummy first")
+{
+    std::vector<cgtd::Interval> intervals;
+    intervals.push_back(mk(0, 3, 0));
+    intervals.push_back(mk(1, 2, 1));
+    intervals.push_back(mk(4, 5, 2));
+    validateEndpoints(intervals);
+
+    const int expected = bruteForceMifSize(intervals);
+    CHECK(maximumInducedForestOn5Size(intervals) == expected);
+}
+
+TEST_CASE("[MaximumInducedForestOn5] Random small instances match brute force (n<=9)")
+{
+    std::mt19937 rng(1234567);
+    for (int trial = 0; trial < 1000; ++trial)
+    {
+        const int n = 10 + (rng() % 5);
+        std::vector<int> perm(2 * n);
+        std::iota(perm.begin(), perm.end(), 0);
+        std::shuffle(perm.begin(), perm.end(), rng);
+
+        auto intervals = makeIntervalsFromPermutation(perm);
+        for (int i = 0; i < n; ++i)
+        {
+            intervals[i].Index = i;
+        }
+        validateEndpoints(intervals);
+
+        const int expected = bruteForceMifSize(intervals);
+        CHECK(maximumInducedForestOn5Size(intervals) == expected);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a MaximumInducedForestOn5 implementation based on the O(n^5) dynamic program with memoised LD/RD/ROOT helpers
- expose the solver through a new public header and compute method
- add doctest coverage that checks the implementation against brute-force solutions on hand-crafted and random instances

## Testing
- ctest --test-dir build -R MaximumInducedForestOn5 --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68eb4a288c7483268890d3ae867fa116